### PR TITLE
퀴즈 공유 기능 일부 구현(제작 퀴즈 전달 부)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,10 @@ dependencies {
     //Splash
     implementation(libs.androidx.core.splashscreen)
 
+    // Glide
+    implementation (libs.glide)
+    annotationProcessor(libs.glide.compiler)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/sw/wordgarden/app/di/UseCaseModule.kt
+++ b/app/src/main/java/com/sw/wordgarden/app/di/UseCaseModule.kt
@@ -36,6 +36,8 @@ import com.sw.wordgarden.domain.usecase.ReportFriendUseCase
 import com.sw.wordgarden.domain.usecase.ReportFriendUseCaseImpl
 import com.sw.wordgarden.domain.usecase.SaveUidUseCase
 import com.sw.wordgarden.domain.usecase.SaveUidUseCaseImpl
+import com.sw.wordgarden.domain.usecase.ShareQuizUseCase
+import com.sw.wordgarden.domain.usecase.ShareQuizUseCaseImpl
 import com.sw.wordgarden.domain.usecase.UpdateTreeUseCase
 import com.sw.wordgarden.domain.usecase.UpdateTreeUseCaseImpl
 import com.sw.wordgarden.domain.usecase.UpdateUserUseCase
@@ -156,6 +158,12 @@ abstract class UseCaseModule {
     abstract fun bindSaveUidUseCase(
         saveUidUseCaseImpl: SaveUidUseCaseImpl
     ): SaveUidUseCase
+
+    @Binds
+    @ViewModelScoped
+    abstract fun bindShareQuizUseCase(
+        shareQuizUseCase: ShareQuizUseCaseImpl
+    ): ShareQuizUseCase
 
     @Binds
     @ViewModelScoped

--- a/app/src/main/java/com/sw/wordgarden/data/datasource/remote/Retrofit/Service.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/datasource/remote/Retrofit/Service.kt
@@ -36,8 +36,11 @@ interface Service {
     //    @POST("login/login")
     suspend fun reportFriend(@Body friendId: String, contents: String): Response<Unit>
 
-    @GET("/user/friendlist/{uid}")
+    @GET("user/friendlist/{uid}")
     suspend fun getFriendList(@Path("uid") uid: String): Response<List<UserDto>>
+
+    @POST("sq/share") //TODO: 서버 구현 시 수정
+    suspend fun shareQuiz(@Body uid: String, quizTitle: String, friendId: String): Response<Unit>
 
     //word
     //    @POST("login/login")

--- a/app/src/main/java/com/sw/wordgarden/data/datasource/remote/Retrofit/Service.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/datasource/remote/Retrofit/Service.kt
@@ -36,8 +36,8 @@ interface Service {
     //    @POST("login/login")
     suspend fun reportFriend(@Body friendId: String, contents: String): Response<Unit>
 
-    //    @POST("login/login")
-    suspend fun getFriendList(@Body uid: String): Response<List<UserDto>>
+    @GET("/user/friendlist/{uid}")
+    suspend fun getFriendList(@Path("uid") uid: String): Response<List<UserDto>>
 
     //word
     //    @POST("login/login")

--- a/app/src/main/java/com/sw/wordgarden/data/datasource/remote/ServerDataSource.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/datasource/remote/ServerDataSource.kt
@@ -19,6 +19,7 @@ interface ServerDataSource {
     suspend fun deleteFriend(friendId: String)
     suspend fun reportFriend(friendId: String, contents: String)
     suspend fun getFriendList(): List<UserDto>?
+    suspend fun shareQuiz(quizTitle: String, friendUid: String)
 
     //words
     suspend fun insertLikedWord(word: WordDto)

--- a/app/src/main/java/com/sw/wordgarden/data/datasource/remote/ServerDataSourceImpl.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/datasource/remote/ServerDataSourceImpl.kt
@@ -19,6 +19,7 @@ class ServerDataSourceImpl @Inject constructor(
 
     private val TAG = "ServerDataSourceImpl"
 
+    //user
     override suspend fun insertUser(signUpDto: SignUpDto) {
         try {
             val response = service.insertUser(signUpDto)
@@ -53,6 +54,7 @@ class ServerDataSourceImpl @Inject constructor(
         }
     }
 
+    //friends
     override suspend fun insertFriend(friendId: String) {
         TODO("Not yet implemented")
     }
@@ -66,9 +68,22 @@ class ServerDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getFriendList(): List<UserDto>? {
-        TODO("Not yet implemented")
+        return try {
+            val uid = getUid()
+
+            val response = service.getFriendList(uid!!)
+            if (!response.isSuccessful) {
+                throw HttpException(response)
+            } else {
+                response.body()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
     }
 
+    //words
     override suspend fun insertLikedWord(word: WordDto) {
         TODO("Not yet implemented")
     }
@@ -85,6 +100,7 @@ class ServerDataSourceImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
+    //quizzes
     override suspend fun insertQuizList(quizList: QuizListDto) {
         try {
             val uid = getUid()
@@ -127,6 +143,7 @@ class ServerDataSourceImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
+    //garden
     override suspend fun updateTree(treeId: String) {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/com/sw/wordgarden/data/datasource/remote/ServerDataSourceImpl.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/datasource/remote/ServerDataSourceImpl.kt
@@ -83,6 +83,20 @@ class ServerDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun shareQuiz(quizTitle: String, friendUid: String) {
+        try {
+            val uid = getUid()
+
+            val response = service.shareQuiz(uid!!, quizTitle, friendUid)
+            if (!response.isSuccessful) {
+                throw HttpException(response)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw e
+        }
+    }
+
     //words
     override suspend fun insertLikedWord(word: WordDto) {
         TODO("Not yet implemented")

--- a/app/src/main/java/com/sw/wordgarden/data/mapper/ServerMapper.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/mapper/ServerMapper.kt
@@ -16,6 +16,35 @@ import com.sw.wordgarden.domain.entity.UserEntity
 import com.sw.wordgarden.domain.entity.WordEntity
 
 object ServerMapper {
+    //user
+    fun UserDto.toEntity() = UserEntity(
+        uid = uid,
+        point = point,
+        rank = rank,
+        nickname = nickname,
+        email = email,
+        thumbnail = thumbnail,
+        url = url
+    )
+
+    fun SignUpEntity.toDto() = SignUpDto(
+        uid = uid,
+        nickname = nickname,
+        provider = provider,
+    )
+
+    //friends
+
+    //words
+    fun WordDto.toEntity() = WordEntity(
+        id = id,
+        title = title,
+        description = description,
+        thumbnail = thumbnail,
+        category = category
+    )
+
+    //quizzes
     fun QuizDto.toEntity() = QuizEntity(
         question = question,
         answer = answer,
@@ -55,37 +84,6 @@ object ServerMapper {
         answerNumber = answerNumber,
     )
 
-    fun TreeDto.toEntity() = TreeEntity(
-        id = id,
-        name = name,
-        image = image,
-        growth = growth
-    )
-
-    fun UserDto.toEntity() = UserEntity(
-        uid = uid,
-        point = point,
-        rank = rank,
-        nickname = nickname,
-        email = email,
-        thumbnail = thumbnail,
-        url = url
-    )
-
-    fun SignUpEntity.toDto() = SignUpDto(
-        uid = uid,
-        nickname = nickname,
-        provider = provider,
-    )
-
-    fun WordDto.toEntity() = WordEntity(
-        id = id,
-        title = title,
-        description = description,
-        thumbnail = thumbnail,
-        category = category
-    )
-
     private fun quizDtoToEntity(quiz: List<QuizDto>?): List<QuizEntity> =
         quiz?.map { it.toEntity() } ?: emptyList()
 
@@ -98,4 +96,11 @@ object ServerMapper {
     private fun quizResultEntityToDto(quiz: List<QuizResultEntity>?): List<QuizResultDto> =
         quiz?.map { it.toDto() } ?: emptyList()
 
+    //garden
+    fun TreeDto.toEntity() = TreeEntity(
+        id = id,
+        name = name,
+        image = image,
+        growth = growth
+    )
 }

--- a/app/src/main/java/com/sw/wordgarden/data/repository/FriendRepositoryImpl.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/repository/FriendRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.sw.wordgarden.data.repository
 
 import com.sw.wordgarden.data.datasource.remote.ServerDataSource
+import com.sw.wordgarden.data.mapper.ServerMapper.toEntity
 import com.sw.wordgarden.domain.entity.UserEntity
 import com.sw.wordgarden.domain.repository.FriendRepository
 import javax.inject.Inject
@@ -20,7 +21,6 @@ class FriendRepositoryImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun getFriendList(): List<UserEntity>? {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getFriendList(): List<UserEntity> =
+        serverDataSource.getFriendList()?.map { it.toEntity() } ?: emptyList()
 }

--- a/app/src/main/java/com/sw/wordgarden/data/repository/FriendRepositoryImpl.kt
+++ b/app/src/main/java/com/sw/wordgarden/data/repository/FriendRepositoryImpl.kt
@@ -23,4 +23,8 @@ class FriendRepositoryImpl @Inject constructor(
 
     override suspend fun getFriendList(): List<UserEntity> =
         serverDataSource.getFriendList()?.map { it.toEntity() } ?: emptyList()
+
+    override suspend fun shareQuiz(quizTitle: String, friendUid: String) {
+        serverDataSource.shareQuiz(quizTitle, friendUid)
+    }
 }

--- a/app/src/main/java/com/sw/wordgarden/domain/repository/FriendRepository.kt
+++ b/app/src/main/java/com/sw/wordgarden/domain/repository/FriendRepository.kt
@@ -7,4 +7,5 @@ interface FriendRepository {
     suspend fun deleteFriend(friendId: String)
     suspend fun reportFriend(friendId: String, contents: String)
     suspend fun getFriendList(): List<UserEntity>?
+    suspend fun shareQuiz(quizTitle: String, friendUid: String)
 }

--- a/app/src/main/java/com/sw/wordgarden/domain/usecase/GetFriendListUseCase.kt
+++ b/app/src/main/java/com/sw/wordgarden/domain/usecase/GetFriendListUseCase.kt
@@ -3,5 +3,5 @@ package com.sw.wordgarden.domain.usecase
 import com.sw.wordgarden.domain.entity.UserEntity
 
 interface GetFriendListUseCase {
-    suspend operator fun invoke(uid: String): List<UserEntity>?
+    suspend operator fun invoke(): List<UserEntity>?
 }

--- a/app/src/main/java/com/sw/wordgarden/domain/usecase/GetFriendListUseCaseImpl.kt
+++ b/app/src/main/java/com/sw/wordgarden/domain/usecase/GetFriendListUseCaseImpl.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class GetFriendListUseCaseImpl @Inject constructor(
     private val friendRepository: FriendRepository
 ) : GetFriendListUseCase {
-    override suspend fun invoke(uid: String): List<UserEntity>? {
-        TODO("Not yet implemented")
+    override suspend fun invoke(): List<UserEntity>? {
+        return friendRepository.getFriendList()
     }
 }

--- a/app/src/main/java/com/sw/wordgarden/domain/usecase/ShareQuizUseCase.kt
+++ b/app/src/main/java/com/sw/wordgarden/domain/usecase/ShareQuizUseCase.kt
@@ -1,0 +1,5 @@
+package com.sw.wordgarden.domain.usecase
+
+interface ShareQuizUseCase {
+    suspend operator fun invoke(quizTitle: String, friendUid: String)
+}

--- a/app/src/main/java/com/sw/wordgarden/domain/usecase/ShareQuizUseCaseImpl.kt
+++ b/app/src/main/java/com/sw/wordgarden/domain/usecase/ShareQuizUseCaseImpl.kt
@@ -1,0 +1,12 @@
+package com.sw.wordgarden.domain.usecase
+
+import com.sw.wordgarden.domain.repository.FriendRepository
+import javax.inject.Inject
+
+class ShareQuizUseCaseImpl @Inject constructor(
+    private val friendRepository: FriendRepository
+) : ShareQuizUseCase {
+    override suspend fun invoke(quizTitle: String, friendUid: String) {
+        friendRepository.shareQuiz(quizTitle, friendUid)
+    }
+}

--- a/app/src/main/java/com/sw/wordgarden/presentation/model/FriendModel.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/model/FriendModel.kt
@@ -1,0 +1,7 @@
+package com.sw.wordgarden.presentation.model
+
+data class FriendModel (
+    val uid: String,
+    val nickname: String,
+    val thumbnail: String,
+)

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/main/MainActivity.kt
@@ -30,14 +30,17 @@ class MainActivity : AppCompatActivity() {
 
         setupSplash()
         setupUi()
-//        goLogin()
+//        goLogin() //test를 위해 주석처리
 
         /**
-         * 테스트용 화면 이동 코드
+         * test code
          * TODO: nav 개발 후 테스트 코드 삭제
          */
         goQuiz()
 //        goMy()
+        /**
+         * test code end
+         */
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/main/MainActivity.kt
@@ -31,8 +31,13 @@ class MainActivity : AppCompatActivity() {
         setupSplash()
         setupUi()
 //        goLogin()
-//        goQuiz()
-        goMy()
+
+        /**
+         * 테스트용 화면 이동 코드
+         * TODO: nav 개발 후 테스트 코드 삭제
+         */
+        goQuiz()
+//        goMy()
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/makequiz/MakeQuizFragment.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/makequiz/MakeQuizFragment.kt
@@ -15,6 +15,8 @@ import com.sw.wordgarden.R
 import com.sw.wordgarden.databinding.FragmentMakeQuizBinding
 import com.sw.wordgarden.presentation.model.DefaultEvent
 import com.sw.wordgarden.presentation.model.SelfQuizModel
+import com.sw.wordgarden.presentation.ui.quiz.sharequiz.ShareQuizFragment
+import com.sw.wordgarden.presentation.ui.quiz.sharequiz.ShareQuizFragment.Companion.MAKE_TO_SHARE_BUNDLE_KEY
 import com.sw.wordgarden.presentation.util.ToastMaker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -42,11 +44,15 @@ class MakeQuizFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        shareQuiz("testQuiz4")
-
         setupUi()
         setUpListener()
         setupObserver()
+
+        /**
+         * 테스트용 코드
+         * TODO: 퀴즈 공유 구현 후 테스트 코드 삭제
+         */
+        goShare("test title")
     }
 
     private fun setupUi() = with(binding) {
@@ -125,11 +131,24 @@ class MakeQuizFragment : Fragment() {
         Log.i(TAG, "서버에 퀴즈 추가 요청 : $title || $onlyQuizList")
         viewmodel.insertQuiz(title, onlyQuizList)
 
-        goShare()
+        goShare(title)
     }
 
-    private fun goShare() {
+    private fun goShare(title: String) {
         //findNavController().navigate(해당 화면)
+
+        /**
+         * nav 적용 전 임시 이동 코드
+         */
+        val bundle = Bundle()
+        bundle.putString(MAKE_TO_SHARE_BUNDLE_KEY, title)
+
+        val shareQuizFragment = ShareQuizFragment()
+        shareQuizFragment.arguments = bundle
+
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.cl_main, shareQuizFragment)
+            .commit()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/makequiz/MakeQuizFragment.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/makequiz/MakeQuizFragment.kt
@@ -31,7 +31,8 @@ class MakeQuizFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewmodel: MakeQuizViewModel by viewModels()
-    private val onlyQuizList: List<SelfQuizModel> = List(10) { SelfQuizModel("test", "test") }
+
+    private val onlyQuizList: List<SelfQuizModel> = List(10) { SelfQuizModel("", "") }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -47,12 +48,6 @@ class MakeQuizFragment : Fragment() {
         setupUi()
         setUpListener()
         setupObserver()
-
-        /**
-         * 테스트용 코드
-         * TODO: 퀴즈 공유 구현 후 테스트 코드 삭제
-         */
-        goShare("test title")
     }
 
     private fun setupUi() = with(binding) {
@@ -138,7 +133,8 @@ class MakeQuizFragment : Fragment() {
         //findNavController().navigate(해당 화면)
 
         /**
-         * nav 적용 전 임시 이동 코드
+         * test code
+         * TODO: nav 개발 후 테스트 코드 삭제
          */
         val bundle = Bundle()
         bundle.putString(MAKE_TO_SHARE_BUNDLE_KEY, title)
@@ -149,6 +145,9 @@ class MakeQuizFragment : Fragment() {
         parentFragmentManager.beginTransaction()
             .replace(R.id.cl_main, shareQuizFragment)
             .commit()
+        /**
+         * test code end
+         */
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/sharequiz/ShareQuizAdapter.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/sharequiz/ShareQuizAdapter.kt
@@ -1,0 +1,104 @@
+package com.sw.wordgarden.presentation.ui.quiz.sharequiz
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Filter
+import android.widget.Filterable
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.sw.wordgarden.R
+import com.sw.wordgarden.databinding.ItemFriendsShareBinding
+import com.sw.wordgarden.presentation.model.FriendModel
+import java.util.Locale
+
+@SuppressLint("NotifyDataSetChanged")
+class ShareQuizAdapter(
+    private val friendItemListener: FriendItemListener
+) : ListAdapter<FriendModel, ShareQuizAdapter.ShareQuizViewHolder>(DIFF_UTIL), Filterable {
+
+    private var friendList: List<FriendModel> = emptyList()
+    private var filteredFriendList: List<FriendModel> = emptyList()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ShareQuizViewHolder {
+        return ShareQuizViewHolder(
+            ItemFriendsShareBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            parent.context
+        )
+    }
+
+    override fun onBindViewHolder(holder: ShareQuizViewHolder, position: Int) {
+        holder.bind(filteredFriendList[position])
+    }
+
+    override fun getItemCount(): Int {
+        return filteredFriendList.size
+    }
+
+    override fun submitList(list: List<FriendModel>?) {
+        friendList = list ?: emptyList()
+        filteredFriendList = friendList
+        notifyDataSetChanged()
+    }
+
+    override fun getFilter(): Filter {
+        return object : Filter() {
+            override fun performFiltering(constraint: CharSequence?): FilterResults {
+                val query = constraint?.toString()?.lowercase(Locale.getDefault()) ?: ""
+                filteredFriendList = if (query.isEmpty()) {
+                    friendList
+                } else {
+                    friendList.filter {
+                        it.nickname.lowercase(Locale.getDefault()).contains(query)
+                    }
+                }
+                return FilterResults().apply { values = filteredFriendList }
+            }
+
+            override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
+                filteredFriendList = (results?.values as List<*>).filterIsInstance<FriendModel>()
+                notifyDataSetChanged()
+            }
+        }
+    }
+
+    inner class ShareQuizViewHolder(
+        private val binding: ItemFriendsShareBinding,
+        private val context: Context
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: FriendModel) = with(binding) {
+            Glide.with(context)
+                .load(item.thumbnail)
+                .error(R.drawable.bg_filled_indicator)
+                .fallback(R.drawable.bg_filled_indicator)
+                .into(ivFriendShareThumbnail)
+
+            tvFriendShareNickname.text = item.nickname
+
+            root.setOnClickListener {
+                friendItemListener.onItemClicked(item)
+            }
+        }
+    }
+
+    companion object {
+        private val DIFF_UTIL = object : DiffUtil.ItemCallback<FriendModel>() {
+            override fun areItemsTheSame(oldItem: FriendModel, newItem: FriendModel): Boolean {
+                return oldItem.uid == newItem.uid
+            }
+
+            override fun areContentsTheSame(oldItem: FriendModel, newItem: FriendModel): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+
+    interface FriendItemListener {
+        fun onItemClicked(item: FriendModel)
+    }
+}
+
+

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/sharequiz/ShareQuizFragment.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/sharequiz/ShareQuizFragment.kt
@@ -1,12 +1,24 @@
 package com.sw.wordgarden.presentation.ui.quiz.sharequiz
 
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.sw.wordgarden.R
 import com.sw.wordgarden.databinding.FragmentShareQuizBinding
+import com.sw.wordgarden.presentation.model.DefaultEvent
+import com.sw.wordgarden.presentation.model.FriendModel
+import com.sw.wordgarden.presentation.util.ToastMaker
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class ShareQuizFragment : Fragment() {
@@ -14,16 +26,133 @@ class ShareQuizFragment : Fragment() {
     private var _binding: FragmentShareQuizBinding? = null
     private val binding get() = _binding!!
 
+    private val viewmodel: ShareQuizViewModel by viewModels()
+    private val adapter: ShareQuizAdapter by lazy {
+        ShareQuizAdapter(object : ShareQuizAdapter.FriendItemListener {
+            override fun onItemClicked(item: FriendModel) {
+                val builder = AlertDialog.Builder(requireActivity())
+                builder.setMessage(R.string.share_quiz_msg_share)
+                builder.setPositiveButton(R.string.common_positive) { _, _ ->
+                    viewmodel.shareQuiz(quizTitle, item.uid)
+                }
+                builder.setNegativeButton(R.string.common_negative) { _, _ -> }
+                builder.show()
+            }
+        })
+    }
+    private lateinit var quizTitle: String
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        setupData()
+
         _binding = FragmentShareQuizBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    private fun setupData() {
+        quizTitle = arguments?.getString(MAKE_TO_SHARE_BUNDLE_KEY) ?: ""
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupUi()
+        setupListener()
+
+        /**
+         * test code
+         * TODO: 서버 연동 후 더미 test code 삭제
+         */
+        val dummyFriends = listOf(
+            FriendModel(uid = "test_friend_uid_1", nickname = "test_friend_1", thumbnail = ""),
+            FriendModel(uid = "test_friend_uid_2", nickname = "test_friend_2", thumbnail = ""),
+            FriendModel(uid = "test_friend_uid_3", nickname = "test_friend_23", thumbnail = ""),
+        )
+        adapter.submitList(dummyFriends)
+
+        if (dummyFriends.isEmpty()) {
+            binding.rvShareQuiz.visibility = View.INVISIBLE
+            binding.tvShareQuizNoFriends.visibility = View.VISIBLE
+        } else {
+            binding.rvShareQuiz.visibility = View.VISIBLE
+            binding.tvShareQuizNoFriends.visibility = View.INVISIBLE
+        }
+        /**
+         * test code end
+         */
+
+//        setupObserver()
+    }
+
+    private fun setupUi() = with(binding) {
+        rvShareQuiz.adapter = adapter
+    }
+
+    private fun setupListener() = with(binding) {
+        btnShareQuizBack.setOnClickListener {
+            //findNavController().popBackStack()
+        }
+
+        etShareQuizInputTitle.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
+            override fun afterTextChanged(s: Editable?) { }
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                adapter.filter.filter(s)
+            }
+        })
+    }
+
+    private fun setupObserver() {
+        lifecycleScope.launch {
+            viewmodel.getFriendEvent.flowWithLifecycle(lifecycle).collectLatest { event ->
+                when (event) {
+                    is DefaultEvent.Failure -> {
+                        ToastMaker.make(requireContext(), event.msg)
+                    }
+
+                    DefaultEvent.Success -> {}
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            viewmodel.getFriendList.flowWithLifecycle(lifecycle).collectLatest { friends ->
+                adapter.submitList(friends)
+
+                if (friends.isEmpty()) {
+                    binding.rvShareQuiz.visibility = View.INVISIBLE
+                    binding.tvShareQuizNoFriends.visibility = View.VISIBLE
+                } else {
+                    binding.rvShareQuiz.visibility = View.VISIBLE
+                    binding.tvShareQuizNoFriends.visibility = View.INVISIBLE
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            viewmodel.shareEvent.flowWithLifecycle(lifecycle).collectLatest { event ->
+                when (event) {
+                    is DefaultEvent.Failure -> {
+                        ToastMaker.make(requireContext(), event.msg)
+                    }
+
+                    DefaultEvent.Success -> {
+                        ToastMaker.make(requireContext(), R.string.share_quiz_msg_success_sharing)
+                    }
+                }
+            }
+        }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        const val MAKE_TO_SHARE_BUNDLE_KEY = "MAKE_TO_SHARE_BUNDLE_KEY"
     }
 }

--- a/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/sharequiz/ShareQuizViewModel.kt
+++ b/app/src/main/java/com/sw/wordgarden/presentation/ui/quiz/sharequiz/ShareQuizViewModel.kt
@@ -1,4 +1,75 @@
 package com.sw.wordgarden.presentation.ui.quiz.sharequiz
 
-class ShareQuizViewModel {
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sw.wordgarden.R
+import com.sw.wordgarden.domain.usecase.GetFriendListUseCase
+import com.sw.wordgarden.domain.usecase.ShareQuizUseCase
+import com.sw.wordgarden.presentation.model.DefaultEvent
+import com.sw.wordgarden.presentation.model.FriendModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ShareQuizViewModel @Inject constructor(
+    private val getFriendListUseCase: GetFriendListUseCase,
+    private val shareQuizUseCase: ShareQuizUseCase
+) : ViewModel() {
+
+    private val _getFriendEvent = MutableSharedFlow<DefaultEvent>()
+    val getFriendEvent: SharedFlow<DefaultEvent> = _getFriendEvent.asSharedFlow()
+
+    private val _getFriendList = MutableStateFlow<List<FriendModel>>(emptyList())
+    val getFriendList: StateFlow<List<FriendModel>> = _getFriendList.asStateFlow()
+
+    private val _shareEvent = MutableSharedFlow<DefaultEvent>()
+    val shareEvent: SharedFlow<DefaultEvent> = _shareEvent.asSharedFlow()
+
+    init {
+        getFriends()
+    }
+
+    private fun getFriends() =
+        viewModelScope.launch {
+            runCatching {
+                val friendList = getFriendListUseCase()?.map {
+                    FriendModel(
+                        uid = it.uid ?: "",
+                        nickname = it.nickname ?: "",
+                        thumbnail = it.thumbnail ?: ""
+                    )
+                }
+
+                if (friendList != null) {
+                    _getFriendList.update { friendList }
+                } else {
+                    _getFriendList.update { emptyList() }
+                }
+
+            }.onFailure {
+                _getFriendEvent.emit(DefaultEvent.Failure(R.string.share_quiz_msg_fail_load_friends))
+            }.onSuccess {
+                _getFriendEvent.emit(DefaultEvent.Success)
+            }
+        }
+
+    fun shareQuiz(quizTitle: String, friendUid: String) {
+        viewModelScope.launch {
+            runCatching {
+                shareQuizUseCase.invoke(quizTitle, friendUid)
+            }.onFailure {
+                _shareEvent.emit(DefaultEvent.Failure(R.string.share_quiz_msg_fail_to_share))
+            }.onSuccess {
+                _shareEvent.emit(DefaultEvent.Success)
+            }
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_share_quiz.xml
+++ b/app/src/main/res/layout/fragment_share_quiz.xml
@@ -44,19 +44,17 @@
         android:id="@+id/cl_share_quiz_inner"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:paddingTop="@dimen/padding_extra_larger"
-        android:paddingStart="24dp"
-        android:paddingEnd="24dp"
         android:background="@drawable/bg_rec_background_50"
+        android:paddingStart="@dimen/padding_medium"
+        android:paddingTop="@dimen/padding_extra_larger"
+        android:paddingEnd="@dimen/padding_medium"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cl_share_quiz_top_bar"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintTop_toBottomOf="@+id/cl_share_quiz_top_bar">
 
         <androidx.appcompat.widget.LinearLayoutCompat
-            android:id="@+id/linearLayout"
+            android:id="@+id/ll_search"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small"
@@ -77,7 +75,7 @@
                 android:src="@drawable/ic_finder" />
 
             <androidx.appcompat.widget.AppCompatEditText
-                android:id="@+id/tv_share_quiz_input_title"
+                android:id="@+id/et_share_quiz_input_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/light_gray"
@@ -93,11 +91,23 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:paddingTop="@dimen/padding_large"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/linearLayout"
-            tools:itemCount="10"
+            app:layout_constraintTop_toBottomOf="@+id/ll_search"
             tools:listitem="@layout/item_friends_share" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_share_quiz_no_friends"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_larger"
+            android:text="@string/share_quiz_no_friends"
+            android:textColor="@color/gray"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/ll_search" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_friends_share.xml
+++ b/app/src/main/res/layout/item_friends_share.xml
@@ -14,7 +14,7 @@
     android:padding="@dimen/padding_large">
 
     <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/circleImageView2"
+        android:id="@+id/iv_friend_share_thumbnail"
         android:layout_width="64dp"
         android:layout_height="64dp"
         android:src="@color/light_khaki"
@@ -22,13 +22,14 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tv_friend_share_nickname"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_extra_larger"
-        android:text="userID"
+        android:text="nickname"
         android:textSize="@dimen/text_smaller"
-        app:layout_constraintBottom_toBottomOf="@+id/circleImageView2"
-        app:layout_constraintStart_toEndOf="@+id/circleImageView2"
-        app:layout_constraintTop_toTopOf="@+id/circleImageView2" />
+        app:layout_constraintBottom_toBottomOf="@+id/iv_friend_share_thumbnail"
+        app:layout_constraintStart_toEndOf="@+id/iv_friend_share_thumbnail"
+        app:layout_constraintTop_toTopOf="@+id/iv_friend_share_thumbnail" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <!-- uid -->
     <string name="uid_msg_fail_check">내부 데이터 읽기에 실패했습니다.</string>
 
-
     <!-- login -->
     <string name="login_google">구글로 계속하기</string>
     <string name="login_naver">네이버로 계속하기</string>
@@ -49,6 +48,15 @@
 
     <string name="share_quiz_title">퀴즈 공유하기</string>
     <string name="share_quiz_description">친구랑 같이 퀴즈를 풀어보세요!</string>
+    <string name="share_quiz_no_friends">아직 친구가 없어요!</string>
+    <string name="share_quiz_msg_fail_load_friends">친구 목록 불러오기에 실패했습니다.</string>
+    <string name="share_quiz_msg_share">친구에게 방금 만든 퀴즈를 공유할게요!</string>
+    <string name="share_quiz_msg_fail_to_share">퀴즈 공유에 실패했어요.</string>
+    <string name="share_quiz_msg_success_sharing">친구에게 퀴즈를 공유했어요!</string>
+
+    <!-- common -->
+    <string name="common_positive">네</string>
+    <string name="common_negative">아니오</string>
 
     <!-- keys -->
     <string name="naver_client_id">fYtp0C5dQV4enao8hy1Q</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ gson = "2.9.0"
 circleimageview = "3.1.0"
 v2User = "2.12.1"
 viewpager2 = "1.1.0"
+glideVersion = "4.16.0"
+
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
@@ -50,6 +52,8 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circleimageview" }
 v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "v2User" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glideVersion" }
+glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glideVersion" }
 
 
 [plugins]


### PR DESCRIPTION
resolved : #21

---

[완성된 기능]
- 제작한 퀴즈를 서버에 전달
- 퀴즈 제작 후 친구 목록으로 이동

[향후 필요한 서버 연동 작업]
- 친구 목록 받아오기
- 퀴즈 공유하기 눌렀을 때 데이터 보내기
(위 두 개 작업에 대한 base code는 모두 작성되었습니다. 향후 BE에서 api 개발 후 테스트 및 개발 내용에 맞게 조정이 필요합니다)

[향후 서버와 함께 작업 필요한 것]
- 퀴즈 공유 받았을 때 알람 띄우기
  - FCM 적용 (#30)


---

[검색 기능 테스트 영상]

[Screen_recording_20240731_201005.webm](https://github.com/user-attachments/assets/234098e8-f01c-45c5-9a1b-8bfc396334b0)

